### PR TITLE
manual method to get express subapps to work with remix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1877,8 +1877,7 @@
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "base": {
       "version": "0.11.2",
@@ -7647,6 +7646,32 @@
         "@types/mdast": "^3.0.0",
         "mdast-util-to-hast": "^11.0.0",
         "unified": "^10.0.0"
+      }
+    },
+    "remix-mount-routes": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/remix-mount-routes/-/remix-mount-routes-0.1.3.tgz",
+      "integrity": "sha512-fn/wMe4F4chmb1j6o1GInFm/GKQXk0R6+C3UWKo51IPKpFE1ErP/B33cmRQNUctUCfZW2urhOqORXsNMgSoCUA==",
+      "requires": {
+        "minimatch": "^5.0.1"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+          "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        }
       }
     },
     "repeat-element": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "express": "^4.18.1",
     "morgan": "^1.10.0",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react-dom": "^17.0.2",
+    "remix-mount-routes": "^0.1.3"
   },
   "devDependencies": {
     "@remix-run/dev": "^1.5.1",

--- a/remix.config.js
+++ b/remix.config.js
@@ -1,10 +1,17 @@
 /**
  * @type {import('@remix-run/dev').AppConfig}
  */
+
+const { mountRoutes } = require("remix-mount-routes");
+
 module.exports = {
   ignoredRouteFiles: ["**/.*"],
   // appDirectory: "app",
   // assetsBuildDirectory: "public/build",
   // serverBuildPath: "build/index.js",
   publicPath: "/example/build/",
+  routes: () => {
+    const routes = mountRoutes("/example", "routes");
+    return routes;
+  },
 };

--- a/server.js
+++ b/server.js
@@ -30,22 +30,20 @@ example.use(express.static("public", { maxAge: "1h" }));
 
 example.use(morgan("tiny"));
 
-example.all(
-  "*",
-  process.env.NODE_ENV === "development"
-    ? (req, res, next) => {
-        purgeRequireCache();
+example.all("*", (req, res, next) => {
+  if (process.env.NODE_ENV === "development") {
+    purgeRequireCache();
+  }
 
-        return createRequestHandler({
-          build: require(BUILD_DIR),
-          mode: process.env.NODE_ENV,
-        })(req, res, next);
-      }
-    : createRequestHandler({
-        build: require(BUILD_DIR),
-        mode: process.env.NODE_ENV,
-      })
-);
+  // req.url is a relative path with no reference to
+  // the mount path so adding it manually
+  req.url = "/example" + req.url;
+
+  return createRequestHandler({
+    build: require(BUILD_DIR),
+    mode: process.env.NODE_ENV,
+  })(req, res, next);
+});
 
 /**************************************************/
 


### PR DESCRIPTION
PR to demonstrate how to make subapps using mountpaths on express work.

With this change the express app will run on the `/example` subpath. 